### PR TITLE
Add Spanish translation

### DIFF
--- a/LevelRange-Turtle.toc
+++ b/LevelRange-Turtle.toc
@@ -1,6 +1,6 @@
 ## Interface: 11200
 ## Title: LevelRange [|cff3fcf26Turtle|r]
-## Version: 2.0.8
+## Version: 2.1.0
 ## Author: Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 ## Notes: Shows the zone level range on the World Map. Now with 100% more turtles!
 ## Notes-esES: Muestra el rango de niveles de zona en el mapa mundial. ¡Ahora con un 100 % más de tortugas!

--- a/LevelRange-Turtle.toc
+++ b/LevelRange-Turtle.toc
@@ -1,9 +1,10 @@
 ## Interface: 11200
 ## Title: LevelRange [|cff3fcf26Turtle|r]
+## Version: 2.0.5
+## Author: Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 ## Notes: Shows the zone level range on the World Map. Now with 100% more turtles!
 ## Notes-esES: Muestra el rango de niveles de zona en el mapa mundial. ¡Ahora con un 100 % más de tortugas!
-## Version: (dev)
-## Author: Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 ## URL: https://github.com/Spartelfant/LevelRange-Turtle
-## SavedVariablesPerCharacter: LevelRangeSettings
+## OptionalDeps: myAddOns
+## SavedVariables: LevelRangeSettings
 LevelRange.xml

--- a/LevelRange-Turtle.toc
+++ b/LevelRange-Turtle.toc
@@ -1,9 +1,9 @@
 ## Interface: 11200
 ## Title: LevelRange [|cff3fcf26Turtle|r]
-## Version: 2.0.5
-## Author: Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 ## Notes: Shows the zone level range on the World Map. Now with 100% more turtles!
+## Notes-esES: Muestra el rango de niveles de zona en el mapa mundial. ¡Ahora con un 100 % más de tortugas!
+## Version: (dev)
+## Author: Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 ## URL: https://github.com/Spartelfant/LevelRange-Turtle
-## OptionalDeps: myAddOns
-## SavedVariables: LevelRangeSettings
+## SavedVariablesPerCharacter: LevelRangeSettings
 LevelRange.xml

--- a/LevelRange.lua
+++ b/LevelRange.lua
@@ -18,7 +18,7 @@
 LEVELRANGE_NAME     = "LevelRange"
 
 -- Version Number
-LEVELRANGE_VERSION  = "2.0.8";
+LEVELRANGE_VERSION  = "2.1.0";
 
 -- Details
 Details = {

--- a/LevelRange.lua
+++ b/LevelRange.lua
@@ -291,14 +291,14 @@ local function lUpdateTooltip(zoneName)
 
         if (side == lTYPE_CONTESTED) then
             title = LEVELRANGE_COLORS.Contested;
-            actualside = "Contested";
+            actualside = lTYPE_CONTESTED;
         else
             if (faction == side) then
                 title = LEVELRANGE_COLORS.Friendly;
-                actualside = "Friendly";
+                actualside = LEVELRANGE_FRIENDLY;
             else
                 title = LEVELRANGE_COLORS.Hostile;
-                actualside = "Hostile";
+                actualside = LEVELRANGE_HOSTILE;
             end
         end
         levels = string.format(LEVELRANGE_LEVELS, min, max);

--- a/LevelRange.xml
+++ b/LevelRange.xml
@@ -4,6 +4,7 @@
     xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
 
   <Script file="localisation.lua"/>
+  <Script file="localisation.es.lua"/>
   <Script file="LevelRange.lua"/>
 
   <!-- Hook OnLoad and OnEvent -->

--- a/Readme.txt
+++ b/Readme.txt
@@ -9,7 +9,7 @@ Details
 ----------------------
 Title: 	        LevelRange
 Interface:      11200
-Version:        2.0.8
+Version:        2.1.0
 
 Author:         Bull3t, Tenyar97, rado-boy, blehz, Spartelfant.
 Addon Website:  https://github.com/Tenyar97/LevelRange-Turtle
@@ -22,6 +22,9 @@ Current Features:
 ----------------------
 Change Log
 ----------------------
+2.1.0 - Update (Spartelfant)
+ [*] Added Spanish translation.
+
 2.0.8 - Update (Spartelfant)
  [*] Fixed location of Dragonmaw Retreat: I had listed it mistakenly as being in Grim Reaches, but it's located in Wetlands.
 

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -15,8 +15,8 @@ if (GetLocale() == "esES") then
   LEVELRANGE_ALLIANCE             = "Alianza";
   LEVELRANGE_HORDE                = "Horda";
   LEVELRANGE_CONTESTED            = "Zona en disputa";
-  LEVELRANGE_FRIENDLY            = "Amistoso";
-  LEVELRANGE_HOSTILE            = "Hostil";
+  LEVELRANGE_FRIENDLY             = "Amistoso";
+  LEVELRANGE_HOSTILE              = "Hostil";
   
   -- Zones
   LEVELRANGE_1KNEEDLES            = "Las Mil Agujas";

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -14,7 +14,9 @@ if (GetLocale() == "esES") then
   -- Factions
   LEVELRANGE_ALLIANCE             = "Alianza";
   LEVELRANGE_HORDE                = "Horda";
-  LEVELRANGE_CONTESTED            = "Zona disputada";
+  LEVELRANGE_CONTESTED            = "Zona en disputa";
+  LEVELRANGE_FRIENDLY            = "Amistoso";
+  LEVELRANGE_HOSTILE            = "Hostil";
   
   -- Zones
   LEVELRANGE_1KNEEDLES            = "Las Mil Agujas";

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -58,7 +58,7 @@ if (GetLocale() == "esES") then
   LEVELRANGE_WESTERNPLAGUE        = "Tierras de la Peste del Oeste";
   LEVELRANGE_WESTFALL             = "Páramos del Poniente";
   LEVELRANGE_WETLANDS             = "Los Humedales";
-  LEVELRANGE_WINTERSPRING         = "Winterspring";
+  LEVELRANGE_WINTERSPRING         = "Cuna del Invierno";
   
   -- Turtle WoW Zones
   LEVELRANGE_BLACKSTONEISLAND     = "Isla Piedra Negra";
@@ -70,8 +70,8 @@ if (GetLocale() == "esES") then
   LEVELRANGE_TELABIM              = "Tel'Abim";
   LEVELRANGE_THALASSIANHIGHLANDS  = "Tierras Altas Thalassianas";
   -- added in patch 1.18
-  LEVELRANGE_GRIMREACHES          = "Grim Reaches";
-  LEVELRANGE_NORTHWIND            = "Northwind";
+  LEVELRANGE_GRIMREACHES          = "Alcances Sombríos";
+  LEVELRANGE_NORTHWIND            = "Viento del Norte";
   LEVELRANGE_BALOR                = "Balor";
   
   -- Sub-zones

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -20,46 +20,46 @@ if (GetLocale() == "esES") then
   LEVELRANGE_1KNEEDLES            = "Las Mil Agujas";
   LEVELRANGE_ALTERAC              = "Alterac Mountains";
   LEVELRANGE_ARATHI               = "Arathi Highlands";
-  LEVELRANGE_ASHENVALE            = "Ashenvale";
+  LEVELRANGE_ASHENVALE            = "Vallefresno";
   LEVELRANGE_AZSHARA              = "Azshara";
   LEVELRANGE_BADLANDS             = "Badlands";
-  LEVELRANGE_BARRENS              = "The Barrens";
+  LEVELRANGE_BARRENS              = "Los Baldíos";
   LEVELRANGE_BLASTEDLANDS         = "Blasted Lands";
   LEVELRANGE_BURNINGSTEPPE        = "Burning Steppes";
-  LEVELRANGE_DARKSHORE            = "Darkshore";
+  LEVELRANGE_DARKSHORE            = "Costa Oscura";
   LEVELRANGE_DEADWINDPASS         = "Deadwind Pass";
   LEVELRANGE_DESOLACE             = "Desolace";
   LEVELRANGE_DUNMOROGH            = "Dun Morogh";
   LEVELRANGE_DUROTAR              = "Durotar";
   LEVELRANGE_DUSKWOOD             = "Duskwood";
-  LEVELRANGE_DUSTWALLOW           = "Dustwallow Marsh";
+  LEVELRANGE_DUSTWALLOW           = "Marjal Revolcafango";
   LEVELRANGE_EASTERNPLAGUE        = "Eastern Plaguelands";
   LEVELRANGE_ELWYNN               = "Elwynn Forest";
-  LEVELRANGE_FELWOOD              = "Felwood";
+  LEVELRANGE_FELWOOD              = "Frondavil";
   LEVELRANGE_FERALAS              = "Feralas";
   LEVELRANGE_HILLSBRAD            = "Hillsbrad Foothills";
   LEVELRANGE_HINTERLANDS          = "The Hinterlands";
   LEVELRANGE_LOCHMODAN            = "Loch Modan";
-  LEVELRANGE_MOONGLADE            = "Moonglade";
+  LEVELRANGE_MOONGLADE            = "Claro de la Luna";
   LEVELRANGE_MULGORE              = "Mulgore";
   LEVELRANGE_REDRIDGE             = "Redridge Mountains";
   LEVELRANGE_SEARINGGORGE         = "Searing Gorge";
   LEVELRANGE_SILITHUS             = "Silithus";
   LEVELRANGE_SILVERPINE           = "Silverpine Forest";
   LEVELRANGE_SORROWS              = "Swamp of Sorrows";
-  LEVELRANGE_STONETALON           = "Stonetalon Mountains";
+  LEVELRANGE_STONETALON           = "Montañas de Colina Roca";
   LEVELRANGE_STRANGLETHORN        = "Stranglethorn Vale";
   LEVELRANGE_TANARIS              = "Tanaris";
   LEVELRANGE_TELDRASSIL           = "Teldrassil";
   LEVELRANGE_TIRISFAL             = "Tirisfal Glades";
-  LEVELRANGE_UNGOROCRATER         = "Un'Goro Crater";
+  LEVELRANGE_UNGOROCRATER         = "Crater Un'Goro";
   LEVELRANGE_WESTERNPLAGUE        = "Western Plaguelands";
   LEVELRANGE_WESTFALL             = "Westfall";
   LEVELRANGE_WETLANDS             = "Wetlands";
   LEVELRANGE_WINTERSPRING         = "Winterspring";
   
   -- Turtle WoW Zones
-  LEVELRANGE_BLACKSTONEISLAND     = "Blackstone Island";
+  LEVELRANGE_BLACKSTONEISLAND     = "Isla Piedra Negra";
   LEVELRANGE_GILLIJIM             = "Gillijim's Isle";
   LEVELRANGE_GILNEAS              = "Gilneas";
   LEVELRANGE_HYJAL                = "Hyjal";
@@ -77,7 +77,7 @@ if (GetLocale() == "esES") then
   LEVELRANGE_IRONFORGE            = "Ironforge";
   LEVELRANGE_ORGRIMMAR            = "Orgrimmar";
   LEVELRANGE_STORMWIND            = "Stormwind City";
-  LEVELRANGE_THUNDERBLUFF         = "Thunder Bluff";
+  LEVELRANGE_THUNDERBLUFF         = "Cima del Trueno";
   LEVELRANGE_UNDERCITY            = "Undercity";
   
   -- Turtle WoW Sub-zones
@@ -90,7 +90,7 @@ if (GetLocale() == "esES") then
   LEVELRANGE_EARTHENRING          = "Earthen Ring";
   
   -- Dungeons
-  LEVELRANGE_INSTANCESTEXT        = "Instances:";
+  LEVELRANGE_INSTANCESTEXT        = "Mazmorras:";
   
   LEVELRANGE_BLACKFATHOMDEEPS     = "Blackfathom Deeps";
   LEVELRANGE_BLACKROCKDEPTH       = "Blackrock Depths";
@@ -124,7 +124,7 @@ if (GetLocale() == "esES") then
   LEVELRANGE_DRAGONMAWRETREAT     = "Dragonmaw Retreat";
   
   -- Raids
-  LEVELRANGE_RAIDSTEXT            = "Raids:";
+  LEVELRANGE_RAIDSTEXT            = "Bandas:";
   
   LEVELRANGE_NAXXRAMAS            = "Naxxramas";
   LEVELRANGE_ONYXIASLAIR          = "Onyxia's Lair";
@@ -193,30 +193,30 @@ if (GetLocale() == "esES") then
 
   LEVELRANGE_OPTIONS              = {};
   LEVELRANGE_OPTIONS[1]           = {   -- Option 1
-      label                       = "Enable LevelRange",
+      label                       = "Habilitado LevelRange",
       option                      = "showLevelRange",
-      tooltip                     = "Show/hide LevelRange tooltip",
+      tooltip                     = "Mostrar/ocultar LevelRange en tooltip",
       children                    = {2, 3, 4, 5},
   };
   LEVELRANGE_OPTIONS[2]           = {   -- Option 2
-      label                       = "Show Instances",
+      label                       = "Mostrar mazmorras",
       option                      = "showInstances",
-      tooltip                     = "Show/hide instances on tooltip",
+      tooltip                     = "Mostrar/ocultar mazmorras en tooltip",
   };
   LEVELRANGE_OPTIONS[3]           = {   -- Option 3
-      label                       = "Show Raids",
+      label                       = "Mostrar bandas",
       option                      = "showRaids",
-      tooltip                     = "Show/hide raids on tooltip",
+      tooltip                     = "Mostar/ocultar bandas en tooltip",
   };
   LEVELRANGE_OPTIONS[4]           = {   -- Option 4
-      label                       = "Show PvP Diplomacy",
+      label                       = "Mostar diplomacia PvP",
       option                      = "showPvP",
-      tooltip                     = "Show/hide PvP Diplomacy on tooltip",
+      tooltip                     = "Mostar/ocultar diplomacia PvP en tooltip",
   };
   LEVELRANGE_OPTIONS[5]           = {   -- Option 5
-      label                       = "Show Fishing level requirement",
+      label                       = "Mostrar nivel de pesca requerido",
       option                      = "showFishing",
-      tooltip                     = "Show/hide Fishing level requirement on tooltip",
+      tooltip                     = "Mostrar/ocultar nivel pesca requerido en tooltip",
   };
   
   LEVELRANGE_DEFAULT_OPTS         = {

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -1,0 +1,228 @@
+--
+-- LevelRange :: Translatable Strings - Spanish
+-- Copyright (c) 2025 Rafael Calafell (rafacc87)
+--
+--------------------------------------------------------------------------------------------------
+-- Localised Strings - Spanish
+--------------------------------------------------------------------------------------------------
+
+if (GetLocale() == "esES") then
+  -- LevelRange
+  LEVELRANGE_NAME                 = "LevelRange";
+  LEVELRANGE_DESCRIPTION          = "Muestra el rango de nivel de la zona en el mapa del mundo";
+  
+  -- Factions
+  LEVELRANGE_ALLIANCE             = "Alianza";
+  LEVELRANGE_HORDE                = "Horda";
+  LEVELRANGE_CONTESTED            = "Zona disputada";
+  
+  -- Zones
+  LEVELRANGE_1KNEEDLES            = "Las Mil Agujas";
+  LEVELRANGE_ALTERAC              = "Alterac Mountains";
+  LEVELRANGE_ARATHI               = "Arathi Highlands";
+  LEVELRANGE_ASHENVALE            = "Ashenvale";
+  LEVELRANGE_AZSHARA              = "Azshara";
+  LEVELRANGE_BADLANDS             = "Badlands";
+  LEVELRANGE_BARRENS              = "The Barrens";
+  LEVELRANGE_BLASTEDLANDS         = "Blasted Lands";
+  LEVELRANGE_BURNINGSTEPPE        = "Burning Steppes";
+  LEVELRANGE_DARKSHORE            = "Darkshore";
+  LEVELRANGE_DEADWINDPASS         = "Deadwind Pass";
+  LEVELRANGE_DESOLACE             = "Desolace";
+  LEVELRANGE_DUNMOROGH            = "Dun Morogh";
+  LEVELRANGE_DUROTAR              = "Durotar";
+  LEVELRANGE_DUSKWOOD             = "Duskwood";
+  LEVELRANGE_DUSTWALLOW           = "Dustwallow Marsh";
+  LEVELRANGE_EASTERNPLAGUE        = "Eastern Plaguelands";
+  LEVELRANGE_ELWYNN               = "Elwynn Forest";
+  LEVELRANGE_FELWOOD              = "Felwood";
+  LEVELRANGE_FERALAS              = "Feralas";
+  LEVELRANGE_HILLSBRAD            = "Hillsbrad Foothills";
+  LEVELRANGE_HINTERLANDS          = "The Hinterlands";
+  LEVELRANGE_LOCHMODAN            = "Loch Modan";
+  LEVELRANGE_MOONGLADE            = "Moonglade";
+  LEVELRANGE_MULGORE              = "Mulgore";
+  LEVELRANGE_REDRIDGE             = "Redridge Mountains";
+  LEVELRANGE_SEARINGGORGE         = "Searing Gorge";
+  LEVELRANGE_SILITHUS             = "Silithus";
+  LEVELRANGE_SILVERPINE           = "Silverpine Forest";
+  LEVELRANGE_SORROWS              = "Swamp of Sorrows";
+  LEVELRANGE_STONETALON           = "Stonetalon Mountains";
+  LEVELRANGE_STRANGLETHORN        = "Stranglethorn Vale";
+  LEVELRANGE_TANARIS              = "Tanaris";
+  LEVELRANGE_TELDRASSIL           = "Teldrassil";
+  LEVELRANGE_TIRISFAL             = "Tirisfal Glades";
+  LEVELRANGE_UNGOROCRATER         = "Un'Goro Crater";
+  LEVELRANGE_WESTERNPLAGUE        = "Western Plaguelands";
+  LEVELRANGE_WESTFALL             = "Westfall";
+  LEVELRANGE_WETLANDS             = "Wetlands";
+  LEVELRANGE_WINTERSPRING         = "Winterspring";
+  
+  -- Turtle WoW Zones
+  LEVELRANGE_BLACKSTONEISLAND     = "Blackstone Island";
+  LEVELRANGE_GILLIJIM             = "Gillijim's Isle";
+  LEVELRANGE_GILNEAS              = "Gilneas";
+  LEVELRANGE_HYJAL                = "Hyjal";
+  LEVELRANGE_LAPIDIS              = "Lapidis Isle";
+  LEVELRANGE_SCARLETENCLAVE       = "Scarlet Enclave";
+  LEVELRANGE_TELABIM              = "Tel'Abim";
+  LEVELRANGE_THALASSIANHIGHLANDS  = "Thalassian Highlands";
+  -- added in patch 1.18
+  LEVELRANGE_GRIMREACHES          = "Grim Reaches";
+  LEVELRANGE_NORTHWIND            = "Northwind";
+  LEVELRANGE_BALOR                = "Balor";
+  
+  -- Sub-zones
+  LEVELRANGE_DARNASSUS            = "Darnassus";
+  LEVELRANGE_IRONFORGE            = "Ironforge";
+  LEVELRANGE_ORGRIMMAR            = "Orgrimmar";
+  LEVELRANGE_STORMWIND            = "Stormwind City";
+  LEVELRANGE_THUNDERBLUFF         = "Thunder Bluff";
+  LEVELRANGE_UNDERCITY            = "Undercity";
+  
+  -- Turtle WoW Sub-zones
+  LEVELRANGE_ALAHTHALAS           = "Alah'Thalas";
+  LEVELRANGE_RUINSOFZULRASAZ      = "Ruins of Zul'rasaz";
+  LEVELRANGE_TIRISFALUPLANDS      = "Tirisfal Uplands";
+  -- added in patch 1.18
+  LEVELRANGE_SLICKWICKOILRIG      = "Slickwick Oil Rig";
+  LEVELRANGE_RUGFORDSMOUNTAINREST = "Rugford's Mountain Rest";
+  LEVELRANGE_EARTHENRING          = "Earthen Ring";
+  
+  -- Dungeons
+  LEVELRANGE_INSTANCESTEXT        = "Instances:";
+  
+  LEVELRANGE_BLACKFATHOMDEEPS     = "Blackfathom Deeps";
+  LEVELRANGE_BLACKROCKDEPTH       = "Blackrock Depths";
+  LEVELRANGE_BLACKROCKSPIRE       = "Blackrock Spire";
+  LEVELRANGE_DEADMINES            = "Deadmines";
+  LEVELRANGE_DIREMAUL             = "Dire Maul";
+  LEVELRANGE_GNOMEREGAN           = "Gnomeregan";
+  LEVELRANGE_MARAUDON             = "Maraudon";
+  LEVELRANGE_RAGEFIRECHASM        = "Ragefire Chasm";
+  LEVELRANGE_RAZORFENDOWNS        = "Razorfen Downs";
+  LEVELRANGE_RAZORFENKRAUL        = "Razorfen Kraul";
+  LEVELRANGE_SCARLETMONASTERY     = "The Scarlet Monastery";
+  LEVELRANGE_SCHOLOMANCE          = "Scholomance";
+  LEVELRANGE_SHADOWFANGKEEP       = "Shadowfang Keep";
+  LEVELRANGE_STOCKADES            = "The Stockades";
+  LEVELRANGE_STRATHOLME           = "Stratholme";
+  LEVELRANGE_SUNKENTEMPLE         = "The Sunken Temple";
+  LEVELRANGE_ULDAMAN              = "Uldaman";
+  LEVELRANGE_WAILINGCAVERNS       = "Wailing Caverns";
+  LEVELRANGE_ZULFARRAK            = "Zul'Farrak";
+  
+  -- Turtle WoW Dungeons
+  LEVELRANGE_COTBLACKMORASS       = "Caverns of Time: The Black Morass";
+  LEVELRANGE_CRESCENTGROVE        = "The Crescent Grove";
+  LEVELRANGE_GILNEASCITY          = "Gilneas City";
+  LEVELRANGE_HATEFORGEQUARRY      = "Hateforge Quarry";
+  LEVELRANGE_KARAZHANCRYPT        = "Karazhan Crypt";
+  LEVELRANGE_STORMWINDVAULT       = "Stormwind Vault";
+  -- added in patch 1.18
+  LEVELRANGE_STORMWROUGHTRUINS    = "Stormwrought Ruins";
+  LEVELRANGE_DRAGONMAWRETREAT     = "Dragonmaw Retreat";
+  
+  -- Raids
+  LEVELRANGE_RAIDSTEXT            = "Raids:";
+  
+  LEVELRANGE_NAXXRAMAS            = "Naxxramas";
+  LEVELRANGE_ONYXIASLAIR          = "Onyxia's Lair";
+  LEVELRANGE_RUINSAHNQIRAJ        = "Ruins of Ahn'Qiraj";
+  LEVELRANGE_TEMPLEAHNQIRAJ       = "Temple of Ahn'Qiraj";
+  LEVELRANGE_ZULGURUB             = "Zul'Gurub";
+  
+  -- Turtle WoW Raids
+  LEVELRANGE_EMERALDSANCTUM       = "Emerald Sanctum";
+  LEVELRANGE_LOWERKARAZHANHALLS   = "Lower Karazhan Halls";
+  
+  -- General Strings
+  LEVELRANGE_LEVELS               = "Niveles %d - %d";
+  LEVELRANGE_FLEVEL               = "Nivel de pesca %d";
+  
+  -- Message Strings
+  LEVELRANGE_LOADEDPREFIX         = "Versión de LevelRange "
+  LEVELRANGE_LOADEDSUFFIX         = " cargada."
+  
+  -- Instances List
+  LEVELRANGE_INSTANCES1           = LEVELRANGE_DEADMINES        .. " (17, 26)"
+  LEVELRANGE_INSTANCES2           = LEVELRANGE_WAILINGCAVERNS   .. " (17, 24)"
+  LEVELRANGE_INSTANCES3           = LEVELRANGE_SHADOWFANGKEEP   .. " (22, 30)"
+  LEVELRANGE_INSTANCES4           = LEVELRANGE_BLACKFATHOMDEEPS .. " (24, 32)"
+  LEVELRANGE_INSTANCES5           = LEVELRANGE_GNOMEREGAN       .. " (29, 38)"
+  LEVELRANGE_INSTANCES6           = LEVELRANGE_RAZORFENKRAUL    .. " (25, 30)"
+  LEVELRANGE_INSTANCES7           = LEVELRANGE_SCARLETMONASTERY .. " (34, 45)"
+  LEVELRANGE_INSTANCES8           = LEVELRANGE_RAZORFENDOWNS    .. " (33, 45)"
+  LEVELRANGE_INSTANCES9           = LEVELRANGE_ULDAMAN          .. " (35, 47)"
+  LEVELRANGE_INSTANCES10          = LEVELRANGE_MARAUDON         .. " (46, 55)"
+  LEVELRANGE_INSTANCES11          = LEVELRANGE_SUNKENTEMPLE     .. " (45, 55)"
+  LEVELRANGE_INSTANCES12          = LEVELRANGE_BLACKROCKDEPTH   .. " (52, 60)"
+  LEVELRANGE_INSTANCES13          = LEVELRANGE_BLACKROCKSPIRE   .. " (58, 60)"
+  LEVELRANGE_INSTANCES14          = LEVELRANGE_STRATHOLME       .. " (58, 60)"
+  LEVELRANGE_INSTANCES15          = LEVELRANGE_DIREMAUL         .. " (55, 60)"
+  LEVELRANGE_INSTANCES16          = LEVELRANGE_SCHOLOMANCE      .. " (57, 60)"
+  LEVELRANGE_INSTANCES17          = LEVELRANGE_RAGEFIRECHASM    .. " (13, 18)"
+  LEVELRANGE_INSTANCES18          = LEVELRANGE_STOCKADES        .. " (24, 32)"
+  LEVELRANGE_INSTANCES19          = LEVELRANGE_ZULFARRAK        .. " (44, 54)"
+  
+  -- Help Strings
+  LEVELRANGE_HELP0                = "Usa los siguientes comandos para cambiar las opciones de LevelRange."
+  LEVELRANGE_HELP1                = "/lr >> Abre el panel de opciones de LevelRange."
+  LEVELRANGE_HELP2                = "/lr toggle >> Alterna la visualización del tooltip de LevelRange."
+  LEVELRANGE_HELP3                = "/lr instances >> Alterna la visualización de mazmorras en el tooltip."
+  LEVELRANGE_HELP4                = "/lr pvp >> Alterna la visualización de diplomacia PvP en el tooltip."
+  LEVELRANGE_HELP5                = "/lr fishing >> Alterna la visualización del requisito mínimo de pesca en el tooltip."
+  LEVELRANGE_HELP6                = "Comando largo: /levelrange también puede usarse en lugar de /lr."
+  
+  -- Toggle Message Strings
+  LEVELRANGE_ON                   = "ACTIVADO"
+  LEVELRANGE_OFF                  = "DESACTIVADO"
+  
+  LEVELRANGE_ENABLED              = "Habilitado."
+  LEVELRANGE_DISABLED             = "Deshabilitado."
+  
+  LEVELRANGE_TOGGLESHOW           = "Tooltip de LevelRange"
+  LEVELRANGE_TOGGLEINSTANCES      = "Mostrar mazmorras de LevelRange"
+  LEVELRANGE_TOGGLERAIDS          = "Mostrar bandas de LevelRange"
+  LEVELRANGE_TOGGLEPVP            = "Mostrar diplomacia PvP de LevelRange"
+  LEVELRANGE_TOGGLEFISHING        = "Mostrar requisito mínimo de pesca"
+  
+  -- Options Frame Strings
+  LEVELRANGE_OPTIONS_TITLE        = "Opciones de LevelRange"
+  LEVELRANGE_OPTIONS_CLOSE        = "Cerrar"
+
+  LEVELRANGE_OPTIONS              = {};
+  LEVELRANGE_OPTIONS[1]           = {   -- Option 1
+      label                       = "Enable LevelRange",
+      option                      = "showLevelRange",
+      tooltip                     = "Show/hide LevelRange tooltip",
+      children                    = {2, 3, 4, 5},
+  };
+  LEVELRANGE_OPTIONS[2]           = {   -- Option 2
+      label                       = "Show Instances",
+      option                      = "showInstances",
+      tooltip                     = "Show/hide instances on tooltip",
+  };
+  LEVELRANGE_OPTIONS[3]           = {   -- Option 3
+      label                       = "Show Raids",
+      option                      = "showRaids",
+      tooltip                     = "Show/hide raids on tooltip",
+  };
+  LEVELRANGE_OPTIONS[4]           = {   -- Option 4
+      label                       = "Show PvP Diplomacy",
+      option                      = "showPvP",
+      tooltip                     = "Show/hide PvP Diplomacy on tooltip",
+  };
+  LEVELRANGE_OPTIONS[5]           = {   -- Option 5
+      label                       = "Show Fishing level requirement",
+      option                      = "showFishing",
+      tooltip                     = "Show/hide Fishing level requirement on tooltip",
+  };
+  
+  LEVELRANGE_DEFAULT_OPTS         = {
+      ["showLevelRange"]          = true,
+      ["showInstances"]           = true,
+      ["showPvP"]                 = true,
+      ["showFishing"]             = true,
+  };
+end

--- a/localisation.es.lua
+++ b/localisation.es.lua
@@ -18,55 +18,55 @@ if (GetLocale() == "esES") then
   
   -- Zones
   LEVELRANGE_1KNEEDLES            = "Las Mil Agujas";
-  LEVELRANGE_ALTERAC              = "Alterac Mountains";
-  LEVELRANGE_ARATHI               = "Arathi Highlands";
+  LEVELRANGE_ALTERAC              = "Montañas de Alterac";
+  LEVELRANGE_ARATHI               = "Tierras Altas de Arathi";
   LEVELRANGE_ASHENVALE            = "Vallefresno";
   LEVELRANGE_AZSHARA              = "Azshara";
-  LEVELRANGE_BADLANDS             = "Badlands";
+  LEVELRANGE_BADLANDS             = "Tierras Inhóspitas";
   LEVELRANGE_BARRENS              = "Los Baldíos";
-  LEVELRANGE_BLASTEDLANDS         = "Blasted Lands";
-  LEVELRANGE_BURNINGSTEPPE        = "Burning Steppes";
+  LEVELRANGE_BLASTEDLANDS         = "Tierras Devastadas";
+  LEVELRANGE_BURNINGSTEPPE        = "Las Estepas Ardientes";
   LEVELRANGE_DARKSHORE            = "Costa Oscura";
-  LEVELRANGE_DEADWINDPASS         = "Deadwind Pass";
+  LEVELRANGE_DEADWINDPASS         = "Paso de la Muerte";
   LEVELRANGE_DESOLACE             = "Desolace";
   LEVELRANGE_DUNMOROGH            = "Dun Morogh";
   LEVELRANGE_DUROTAR              = "Durotar";
-  LEVELRANGE_DUSKWOOD             = "Duskwood";
+  LEVELRANGE_DUSKWOOD             = "Bosque del Ocaso";
   LEVELRANGE_DUSTWALLOW           = "Marjal Revolcafango";
-  LEVELRANGE_EASTERNPLAGUE        = "Eastern Plaguelands";
-  LEVELRANGE_ELWYNN               = "Elwynn Forest";
+  LEVELRANGE_EASTERNPLAGUE        = "Tierras de la Peste del Este";
+  LEVELRANGE_ELWYNN               = "Bosque de Elwynn";
   LEVELRANGE_FELWOOD              = "Frondavil";
   LEVELRANGE_FERALAS              = "Feralas";
-  LEVELRANGE_HILLSBRAD            = "Hillsbrad Foothills";
-  LEVELRANGE_HINTERLANDS          = "The Hinterlands";
+  LEVELRANGE_HILLSBRAD            = "Laderas de Trabalomas";
+  LEVELRANGE_HINTERLANDS          = "Tierras del Interior";
   LEVELRANGE_LOCHMODAN            = "Loch Modan";
   LEVELRANGE_MOONGLADE            = "Claro de la Luna";
   LEVELRANGE_MULGORE              = "Mulgore";
-  LEVELRANGE_REDRIDGE             = "Redridge Mountains";
-  LEVELRANGE_SEARINGGORGE         = "Searing Gorge";
+  LEVELRANGE_REDRIDGE             = "Montañas Crestagrana";
+  LEVELRANGE_SEARINGGORGE         = "La Garganta de Fuego";
   LEVELRANGE_SILITHUS             = "Silithus";
-  LEVELRANGE_SILVERPINE           = "Silverpine Forest";
-  LEVELRANGE_SORROWS              = "Swamp of Sorrows";
+  LEVELRANGE_SILVERPINE           = "Bosque de Argénteos";
+  LEVELRANGE_SORROWS              = "Pantano de las Penas";
   LEVELRANGE_STONETALON           = "Montañas de Colina Roca";
-  LEVELRANGE_STRANGLETHORN        = "Stranglethorn Vale";
+  LEVELRANGE_STRANGLETHORN        = "Vega de Tuercespina";
   LEVELRANGE_TANARIS              = "Tanaris";
   LEVELRANGE_TELDRASSIL           = "Teldrassil";
-  LEVELRANGE_TIRISFAL             = "Tirisfal Glades";
+  LEVELRANGE_TIRISFAL             = "Claros de Tirisfal";
   LEVELRANGE_UNGOROCRATER         = "Crater Un'Goro";
-  LEVELRANGE_WESTERNPLAGUE        = "Western Plaguelands";
-  LEVELRANGE_WESTFALL             = "Westfall";
-  LEVELRANGE_WETLANDS             = "Wetlands";
+  LEVELRANGE_WESTERNPLAGUE        = "Tierras de la Peste del Oeste";
+  LEVELRANGE_WESTFALL             = "Páramos del Poniente";
+  LEVELRANGE_WETLANDS             = "Los Humedales";
   LEVELRANGE_WINTERSPRING         = "Winterspring";
   
   -- Turtle WoW Zones
   LEVELRANGE_BLACKSTONEISLAND     = "Isla Piedra Negra";
-  LEVELRANGE_GILLIJIM             = "Gillijim's Isle";
+  LEVELRANGE_GILLIJIM             = "Isla de Gillijim";
   LEVELRANGE_GILNEAS              = "Gilneas";
   LEVELRANGE_HYJAL                = "Hyjal";
-  LEVELRANGE_LAPIDIS              = "Lapidis Isle";
-  LEVELRANGE_SCARLETENCLAVE       = "Scarlet Enclave";
+  LEVELRANGE_LAPIDIS              = "Isla Lapidis";
+  LEVELRANGE_SCARLETENCLAVE       = "Enclave Escarlata";
   LEVELRANGE_TELABIM              = "Tel'Abim";
-  LEVELRANGE_THALASSIANHIGHLANDS  = "Thalassian Highlands";
+  LEVELRANGE_THALASSIANHIGHLANDS  = "Tierras Altas Thalassianas";
   -- added in patch 1.18
   LEVELRANGE_GRIMREACHES          = "Grim Reaches";
   LEVELRANGE_NORTHWIND            = "Northwind";
@@ -74,11 +74,11 @@ if (GetLocale() == "esES") then
   
   -- Sub-zones
   LEVELRANGE_DARNASSUS            = "Darnassus";
-  LEVELRANGE_IRONFORGE            = "Ironforge";
+  LEVELRANGE_IRONFORGE            = "Forjaz";
   LEVELRANGE_ORGRIMMAR            = "Orgrimmar";
-  LEVELRANGE_STORMWIND            = "Stormwind City";
+  LEVELRANGE_STORMWIND            = "Ciudad de Ventormenta";
   LEVELRANGE_THUNDERBLUFF         = "Cima del Trueno";
-  LEVELRANGE_UNDERCITY            = "Undercity";
+  LEVELRANGE_UNDERCITY            = "Entrañas";
   
   -- Turtle WoW Sub-zones
   LEVELRANGE_ALAHTHALAS           = "Alah'Thalas";

--- a/localisation.lua
+++ b/localisation.lua
@@ -14,6 +14,8 @@ LEVELRANGE_DESCRIPTION          = "Shows the zone level range on the World Map";
 LEVELRANGE_ALLIANCE             = "Alliance";
 LEVELRANGE_HORDE                = "Horde";
 LEVELRANGE_CONTESTED            = "Contested";
+LEVELRANGE_FRIENDLY             = "Friendly";
+LEVELRANGE_HOSTILE              = "Hostile";
 
 -- Zones
 LEVELRANGE_1KNEEDLES            = "Thousand Needles";


### PR DESCRIPTION
This PR adds support for the Spanish language (es_ES) to the addon. It includes:
- A translation file with Spanish strings.
- Updates to the localization system to recognize es_ES.
- Verification that UI elements display correctly when Spanish is selected.