### PR TITLE
Change string.match to string.gsub

### DIFF
--- a/LevelRange.lua
+++ b/LevelRange.lua
@@ -383,7 +383,7 @@ function LevelRange_WorldMapButton_OnUpdate(arg1)
     lLR_OldUpdate(arg1);
 
     local areaNameRaw = WorldMapFrame.areaName or "";
-    local areaNameTrimmed = string.match(areaNameRaw, "^%s*(.-)%s*$"); -- 2.0.6: Added code to trim whitespace to deal with patch 1.18 bug for Northwind zone: In-game name contains trailing space 'Northwind '.
+    local areaNameTrimmed = string.gsub(areaNameRaw, "^%s*(.-)%s*$","%1"); -- 2.0.6: Added code to trim whitespace to deal with patch 1.18 bug for Northwind zone: In-game name contains trailing space 'Northwind '.
     local zoneNum = GetCurrentMapZone();
 
     -- Zone name equivalence map


### PR DESCRIPTION
string.match was not added until Lua 5.1, so on TurtleWow using the 1.12 client, which runs Lua 5.0, you get error for `match` being a nil value.